### PR TITLE
Enable github actions - fixes #4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+name: Puppet Lint
+
+on: [push]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: puppet-lint-action
+        uses: ScottBrenner/puppet-lint-action@1.0.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,22 @@
+name: Build and publish to Puppet Forge
+
+on:
+ push:
+  tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get latest tag
+      run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
+    - name: Clone repository
+      uses: actions/checkout@v1
+      with:
+        ref: ${{ env.RELEASE_VERSION }}
+    - name: Build and publish module
+      uses: barnumbirr/action-forge-publish@v2.3.0
+      env:
+       FORGE_API_KEY: ${{ secrets.FORGE_API_KEY }}
+       REPOSITORY_URL: https://forgeapi.puppet.com/v3/releases


### PR DESCRIPTION
Enables github actions with linting and publishing to puppet forge on tag pushing.